### PR TITLE
Added batch scripts to ease build on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Make sure you have the following dependencies installed on your system.
 
 ### Install
 
-#### Linux
+#### Linux/MacOS
 *[Required]*
 * Clone this repository:
 ```bash

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Make sure you have the following dependencies installed on your system.
 
 ### Install
 
+#### Linux
 *[Required]*
 * Clone this repository:
 ```bash
@@ -250,6 +251,32 @@ $ ./clean.sh
 * Uninstall python package:
 ```bash
 $ ./uninstall.sh
+```
+
+#### Windows
+*[Required]*
+* Clone this repository:
+```bash
+$ git clone https://github.com/the-aerospace-corporation/brainblocks
+```
+* Build and install python package from project directory:
+```bash
+$ cd brainblocks
+$ install.bat
+```
+
+*[Optional]* 
+* Test installation:
+```bash
+$ pytest test/
+```
+* Clean the brainblocks project directory:
+```bash
+$ clean.bat
+```
+* Uninstall python package:
+```bash
+$ uninstall.bat
 ```
 
 ### Run

--- a/clean.bat
+++ b/clean.bat
@@ -1,0 +1,16 @@
+@echo off
+
+REM Remove all known artifacts from CMake and setuptools build processes
+rmdir /s /q cmake_install.cmake > nul 2>&1
+rmdir /s /q CMakeCache.txt > nul 2>&1
+rmdir /s /q Makefile > nul 2>&1
+rmdir /s /q *.a > nul 2>&1
+rmdir /s /q *.so > nul 2>&1
+rmdir /s /q *.lib > nul 2>&1
+rmdir /s /q *.dll > nul 2>&1
+rmdir /s /q CMakeFiles > nul 2>&1
+rmdir /s /q bin > nul 2>&1
+rmdir /s /q build > nul 2>&1
+rmdir /s /q dist > nul 2>&1
+rmdir /s /q *.egg-info > nul 2>&1
+rmdir /s /q .pytest_cache > nul 2>&1

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,45 @@
+@echo off
+
+REM clear previous build
+rmdir /s /q bin > nul 2>&1
+rmdir /s /q b build > nul 2>&1
+rmdir /s /q b dist > nul 2>&1
+mkdir bin
+mkdir build
+mkdir dist
+
+REM change to build directory
+cd build
+
+echo ================================================================================
+echo Compiling BrainBlocks Backend
+echo ================================================================================
+
+cmake ..
+cmake --build . --config Release
+
+echo .
+echo ================================================================================
+echo Installing BrainBlocks Python Bindings
+echo ================================================================================
+
+cd ..
+
+REM install python requirements
+pip install -r requirements.txt
+
+REM uninstall brainblocks from environment
+pip uninstall brainblocks -y
+
+REM create wheel package and install (OPTION #1)
+python setup.py bdist_wheel
+rmdir /s /q "brainblocks.egg-info"
+FOR %%I in (dist\*.whl) DO pip install %%I 
+
+
+REM pip build and install the directory (OPTION #2)
+REM pip install .
+
+REM build egg package and install (OPTION #3)
+REM python setup.py build
+REM python setup.py install

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,0 +1,4 @@
+@echo off
+
+REM uninstall brainblocks from environment
+pip uninstall brainblocks -y


### PR DESCRIPTION
I transcoded the shell scripts to ease building on Windows. 

I was able to build an install brainblocks using the `install.bat`.

Furthermore, all 11 tests passed.